### PR TITLE
[sdk/nodejs] Copy plugin install script to bin dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,10 @@ build_nodejs_sdk: gen_nodejs_sdk
 		yarn run tsc --version && \
 		yarn run tsc
 	cp README.md LICENSE sdk/nodejs/package.json sdk/nodejs/yarn.lock sdk/nodejs/bin/
+	mkdir -p sdk/nodejs/bin/scripts/
+	cp sdk/nodejs/scripts/install-pulumi-plugin.js sdk/nodejs/bin/scripts/
 	sed -i.bak 's/$${VERSION}/$(VERSION)/g' sdk/nodejs/bin/package.json
+	rm sdk/nodejs/bin/package.json.bak
 
 build_python_sdk: gen_python_sdk
 	cd sdk/python/ && \


### PR DESCRIPTION
There is an issue with the way the `install-pulumi-plugin.js` file is generated in the Node.js SDK. It's emitted as a .js file and not listed in `tsconfig.json`, so it doesn't get copied over to the `bin` directory automatically during build. Other providers have some pre-publish scripts that injects another copy of `install-pulumi-plugin.js` in the bin directory before packaging and publishing, which masked this underlying issue.

Until we've fixed the underlying issue, or gotten rid of this install script altogether, the simplest short-term fix is to simply update the Makefile to copy the file over to the bin directory as part of the build.

Fixes #26