### PR TITLE
add importBasePath to schema to fix Go programgen

### DIFF
--- a/.github/workflows/stage-lint.yml
+++ b/.github/workflows/stage-lint.yml
@@ -15,6 +15,9 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
+      # Fixes `error obtaining VCS status: exit status 128`
+      # https://github.com/golangci/golangci-lint/issues/4033
+      - run: git config --global --add safe.directory $GITHUB_WORKSPACE
       - name: Lint
         # TODO: Enable linting after a cleanup commit.
         # Avoiding in this commit so as to not mix code changes w/ CI changes.

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,3 +3,5 @@
 - Generated SDKs for dotnet, python, node and python.
 
 ### Bug Fixes
+
+- Fix Go program generation not referencing the correct pulumi-std path.

--- a/sdk/schema.json
+++ b/sdk/schema.json
@@ -15,6 +15,9 @@
         "Pulumi": "3.*"
       }
     },
+    "go": {
+      "importBasePath": "github.com/pulumi/pulumi-std/sdk/go/std"
+    },
     "nodejs": {
       "dependencies": {
         "@pulumi/pulumi": "^3.0.0"

--- a/std/provider.go
+++ b/std/provider.go
@@ -35,6 +35,9 @@ func Provider() p.Provider {
 						"@pulumi/pulumi": "^3.0.0",
 					},
 				},
+				"go": map[string]any{
+					"importBasePath": "github.com/pulumi/pulumi-std/sdk/go/std",
+				},
 				"csharp": map[string]any{
 					"packageReferences": map[string]string{
 						"Pulumi": "3.*",


### PR DESCRIPTION
Fixes #34
Fixes PR Lints failing

Pulumi convert programgen tries to infer the correct import path in `Go`. This inference is incorrect and has to be overridden in the schema.

I've tested that a locally built `pulumi-resource-std` picked up on `PATH` produces the desired `go.mod`.

```
% pulumi convert main.tf --from tf --language go
Converting from terraform...
Converting to go...
warning: using pulumi-resource-std from $PATH at /home/kdixler/go/bin/pulumi-resource-std
warning: using pulumi-resource-std from $PATH at /home/kdixler/go/bin/pulumi-resource-std
Installing dependencies...

go: finding module for package github.com/pulumi/pulumi-std/sdk/go/std
go: found github.com/pulumi/pulumi-std/sdk/go/std in github.com/pulumi/pulumi-std/sdk v1.4.0
Finished installing dependencies
```

```
% head go.mod
module foo

go 1.21

toolchain go1.21.3

require (
	github.com/pulumi/pulumi-aws/sdk/v6 v6.13.2
	github.com/pulumi/pulumi-std/sdk v1.4.0
	github.com/pulumi/pulumi/sdk/v3 v3.95.0
```

```
% head main.go
package main

import (
	"fmt"

	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/s3"
	"github.com/pulumi/pulumi-std/sdk/go/std"
	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
)
func main() {
```
