### PR TITLE
Switch to API Token for PyPi uploads

### DIFF
--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -15,8 +15,8 @@ env:
   NUGET_PUBLISH_KEY: ${{ secrets.NUGET_PUBLISH_KEY }}
   NUGET_FEED_URL: https://api.nuget.org/v3/index.json
   PUBLISH_NUGET: true
-  PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-  PYPI_USERNAME: "pulumi"
+  PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+  PYPI_USERNAME: __token__
   PUBLISH_PYPI: true
   JAVAVERSION: "11"
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}


### PR DESCRIPTION
Username/Password authentication is no longer supported. This PR migrates to using API Tokens per https://pypi.org/help/#apitoken. We use `__token__` for the username and the org-wide `PYPI_API_TOKEN` secret for the password.

Reference:
- https://github.com/pulumi/pulumi/pull/15048
- https://github.com/pulumi/pulumi-policy/pull/322
- https://github.com/pulumi/ci-mgmt/issues/751
- https://github.com/pulumi/ci-mgmt/pull/767