### PR TITLE
Upgrade version of Go used in CI

### DIFF
--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -114,7 +114,7 @@ jobs:
         dotnetversion:
           - 3.1.301
         goversion:
-          - 1.18.x
+          - 1.21.x
         language:
           - nodejs
           - python

--- a/.github/workflows/stage-publish.yml
+++ b/.github/workflows/stage-publish.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18.x
+          go-version: 1.21.x
       - name: Install pulumictl
         if: ${{ inputs.use-pulumictl }}
         uses: jaxxstorm/action-install-gh-release@v1.5.0

--- a/.github/workflows/stage-test.yml
+++ b/.github/workflows/stage-test.yml
@@ -31,5 +31,5 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.18.x]
+        go-version: [1.21.x]
         go-stable: [true]


### PR DESCRIPTION
In order to upgrade go-git in https://github.com/pulumi/pulumi-std/pull/39 (to address a security vulnerability), we need at least Go 1.19.x.