### PR TITLE
use actions step from local repo

### DIFF
--- a/.github/workflows/pr-tests-command.yaml
+++ b/.github/workflows/pr-tests-command.yaml
@@ -24,6 +24,6 @@ jobs:
 
             [1]: ${{ steps.vars.outputs.run-url }}
   test:
-    uses: pulumi/pulumi-str/.github/workflows/stage-test.yml@main
+    uses: pulumi/pulumi-std/.github/workflows/stage-test.yml@main
     with:
       commit-ref: refs/pull/${{ github.event.client_payload.pull_request.number }}/merge


### PR DESCRIPTION
For some reason we're using stage-test from the pulumi-str repo here, which is still using an outdated version of the Go, making us failing to compile here.  I don't see a strong reason to use this cross repo dependency, so let's just use the version from this repo instead.

Noticed this while trying to run the acceptance tests for https://github.com/pulumi/pulumi-std/pull/48.

Fixes #49 