### PR TITLE
fix GitHub actions uses directive

### DIFF
--- a/.github/workflows/pr-tests-command.yaml
+++ b/.github/workflows/pr-tests-command.yaml
@@ -24,6 +24,6 @@ jobs:
 
             [1]: ${{ steps.vars.outputs.run-url }}
   test:
-    uses: pulumi/pulumi-std/.github/workflows/stage-test.yml@main
+    uses: pulumi/pulumi-std/.github/workflows/stage-test.yml@master
     with:
       commit-ref: refs/pull/${{ github.event.client_payload.pull_request.number }}/merge


### PR DESCRIPTION
The main branch in this repo is called master not main, so we need to use that.