### PR TITLE
Refine comment for cidrsubnet usage

### DIFF
--- a/sdk/dotnet/Cidrsubnet.cs
+++ b/sdk/dotnet/Cidrsubnet.cs
@@ -13,16 +13,18 @@ namespace Pulumi.Std
     {
         /// <summary>
         /// Takes an IP address range in CIDR notation (like 10.0.0.0/8) and extends its prefix
-        /// to include an additional subnet number. For example, cidrsubnet("10.0.0.0/8", netnum: 2, newbits: 8) returns 10.2.0.0/16;
-        /// cidrsubnet("2607:f298:6051:516c::/64", netnum: 2, newbits: 8) returns 2607:f298:6051:516c:200::/72.
+        /// to include an additional subnet number. For example, cidrsubnet("10.0.0.0/8", netnum: 2, newbits: 8)
+        /// returns 10.2.0.0/16; cidrsubnet("2607:f298:6051:516c::/64", netnum: 2, newbits: 8) returns
+        /// 2607:f298:6051:516c:200::/72.
         /// </summary>
         public static Task<CidrsubnetResult> InvokeAsync(CidrsubnetArgs args, InvokeOptions? options = null)
             => global::Pulumi.Deployment.Instance.InvokeAsync<CidrsubnetResult>("std:index:cidrsubnet", args ?? new CidrsubnetArgs(), options.WithDefaults());
 
         /// <summary>
         /// Takes an IP address range in CIDR notation (like 10.0.0.0/8) and extends its prefix
-        /// to include an additional subnet number. For example, cidrsubnet("10.0.0.0/8", netnum: 2, newbits: 8) returns 10.2.0.0/16;
-        /// cidrsubnet("2607:f298:6051:516c::/64", netnum: 2, newbits: 8) returns 2607:f298:6051:516c:200::/72.
+        /// to include an additional subnet number. For example, cidrsubnet("10.0.0.0/8", netnum: 2, newbits: 8)
+        /// returns 10.2.0.0/16; cidrsubnet("2607:f298:6051:516c::/64", netnum: 2, newbits: 8) returns
+        /// 2607:f298:6051:516c:200::/72.
         /// </summary>
         public static Output<CidrsubnetResult> Invoke(CidrsubnetInvokeArgs args, InvokeOptions? options = null)
             => global::Pulumi.Deployment.Instance.Invoke<CidrsubnetResult>("std:index:cidrsubnet", args ?? new CidrsubnetInvokeArgs(), options.WithDefaults());

--- a/sdk/dotnet/Cidrsubnet.cs
+++ b/sdk/dotnet/Cidrsubnet.cs
@@ -13,16 +13,16 @@ namespace Pulumi.Std
     {
         /// <summary>
         /// Takes an IP address range in CIDR notation (like 10.0.0.0/8) and extends its prefix
-        /// to include an additional subnet number. For example, cidrsubnet("10.0.0.0/8", 8, 2) returns 10.2.0.0/16;
-        /// cidrsubnet("2607:f298:6051:516c::/64", 8, 2) returns 2607:f298:6051:516c:200::/72.
+        /// to include an additional subnet number. For example, cidrsubnet("10.0.0.0/8", netnum: 2, newbits: 8) returns 10.2.0.0/16;
+        /// cidrsubnet("2607:f298:6051:516c::/64", netnum: 2, newbits: 8) returns 2607:f298:6051:516c:200::/72.
         /// </summary>
         public static Task<CidrsubnetResult> InvokeAsync(CidrsubnetArgs args, InvokeOptions? options = null)
             => global::Pulumi.Deployment.Instance.InvokeAsync<CidrsubnetResult>("std:index:cidrsubnet", args ?? new CidrsubnetArgs(), options.WithDefaults());
 
         /// <summary>
         /// Takes an IP address range in CIDR notation (like 10.0.0.0/8) and extends its prefix
-        /// to include an additional subnet number. For example, cidrsubnet("10.0.0.0/8", 8, 2) returns 10.2.0.0/16;
-        /// cidrsubnet("2607:f298:6051:516c::/64", 8, 2) returns 2607:f298:6051:516c:200::/72.
+        /// to include an additional subnet number. For example, cidrsubnet("10.0.0.0/8", netnum: 2, newbits: 8) returns 10.2.0.0/16;
+        /// cidrsubnet("2607:f298:6051:516c::/64", netnum: 2, newbits: 8) returns 2607:f298:6051:516c:200::/72.
         /// </summary>
         public static Output<CidrsubnetResult> Invoke(CidrsubnetInvokeArgs args, InvokeOptions? options = null)
             => global::Pulumi.Deployment.Instance.Invoke<CidrsubnetResult>("std:index:cidrsubnet", args ?? new CidrsubnetInvokeArgs(), options.WithDefaults());

--- a/sdk/go/std/cidrsubnet.go
+++ b/sdk/go/std/cidrsubnet.go
@@ -12,8 +12,8 @@ import (
 )
 
 // Takes an IP address range in CIDR notation (like 10.0.0.0/8) and extends its prefix
-// to include an additional subnet number. For example, cidrsubnet("10.0.0.0/8", 8, 2) returns 10.2.0.0/16;
-// cidrsubnet("2607:f298:6051:516c::/64", 8, 2) returns 2607:f298:6051:516c:200::/72.
+// to include an additional subnet number. For example, cidrsubnet("10.0.0.0/8", netnum: 2, newbits: 8) returns 10.2.0.0/16;
+// cidrsubnet("2607:f298:6051:516c::/64", netnum: 2, newbits: 8) returns 2607:f298:6051:516c:200::/72.
 func Cidrsubnet(ctx *pulumi.Context, args *CidrsubnetArgs, opts ...pulumi.InvokeOption) (*CidrsubnetResult, error) {
 	opts = internal.PkgInvokeDefaultOpts(opts)
 	var rv CidrsubnetResult

--- a/sdk/go/std/cidrsubnet.go
+++ b/sdk/go/std/cidrsubnet.go
@@ -12,8 +12,9 @@ import (
 )
 
 // Takes an IP address range in CIDR notation (like 10.0.0.0/8) and extends its prefix
-// to include an additional subnet number. For example, cidrsubnet("10.0.0.0/8", netnum: 2, newbits: 8) returns 10.2.0.0/16;
-// cidrsubnet("2607:f298:6051:516c::/64", netnum: 2, newbits: 8) returns 2607:f298:6051:516c:200::/72.
+// to include an additional subnet number. For example, cidrsubnet("10.0.0.0/8", netnum: 2, newbits: 8)
+// returns 10.2.0.0/16; cidrsubnet("2607:f298:6051:516c::/64", netnum: 2, newbits: 8) returns
+// 2607:f298:6051:516c:200::/72.
 func Cidrsubnet(ctx *pulumi.Context, args *CidrsubnetArgs, opts ...pulumi.InvokeOption) (*CidrsubnetResult, error) {
 	opts = internal.PkgInvokeDefaultOpts(opts)
 	var rv CidrsubnetResult

--- a/sdk/nodejs/cidrsubnet.ts
+++ b/sdk/nodejs/cidrsubnet.ts
@@ -6,8 +6,8 @@ import * as utilities from "./utilities";
 
 /**
  * Takes an IP address range in CIDR notation (like 10.0.0.0/8) and extends its prefix
- * to include an additional subnet number. For example, cidrsubnet("10.0.0.0/8", 8, 2) returns 10.2.0.0/16;
- * cidrsubnet("2607:f298:6051:516c::/64", 8, 2) returns 2607:f298:6051:516c:200::/72.
+ * to include an additional subnet number. For example, cidrsubnet("10.0.0.0/8", netnum: 2, newbits: 8) returns 10.2.0.0/16;
+ * cidrsubnet("2607:f298:6051:516c::/64", netnum: 2, newbits: 8) returns 2607:f298:6051:516c:200::/72.
  */
 export function cidrsubnet(args: CidrsubnetArgs, opts?: pulumi.InvokeOptions): Promise<CidrsubnetResult> {
 
@@ -30,8 +30,8 @@ export interface CidrsubnetResult {
 }
 /**
  * Takes an IP address range in CIDR notation (like 10.0.0.0/8) and extends its prefix
- * to include an additional subnet number. For example, cidrsubnet("10.0.0.0/8", 8, 2) returns 10.2.0.0/16;
- * cidrsubnet("2607:f298:6051:516c::/64", 8, 2) returns 2607:f298:6051:516c:200::/72.
+ * to include an additional subnet number. For example, cidrsubnet("10.0.0.0/8", netnum: 2, newbits: 8) returns 10.2.0.0/16;
+ * cidrsubnet("2607:f298:6051:516c::/64", netnum: 2, newbits: 8) returns 2607:f298:6051:516c:200::/72.
  */
 export function cidrsubnetOutput(args: CidrsubnetOutputArgs, opts?: pulumi.InvokeOptions): pulumi.Output<CidrsubnetResult> {
     return pulumi.output(args).apply((a: any) => cidrsubnet(a, opts))

--- a/sdk/nodejs/cidrsubnet.ts
+++ b/sdk/nodejs/cidrsubnet.ts
@@ -6,8 +6,9 @@ import * as utilities from "./utilities";
 
 /**
  * Takes an IP address range in CIDR notation (like 10.0.0.0/8) and extends its prefix
- * to include an additional subnet number. For example, cidrsubnet("10.0.0.0/8", netnum: 2, newbits: 8) returns 10.2.0.0/16;
- * cidrsubnet("2607:f298:6051:516c::/64", netnum: 2, newbits: 8) returns 2607:f298:6051:516c:200::/72.
+ * to include an additional subnet number. For example, cidrsubnet("10.0.0.0/8", netnum: 2, newbits: 8)
+ * returns 10.2.0.0/16; cidrsubnet("2607:f298:6051:516c::/64", netnum: 2, newbits: 8) returns
+ * 2607:f298:6051:516c:200::/72.
  */
 export function cidrsubnet(args: CidrsubnetArgs, opts?: pulumi.InvokeOptions): Promise<CidrsubnetResult> {
 
@@ -30,8 +31,9 @@ export interface CidrsubnetResult {
 }
 /**
  * Takes an IP address range in CIDR notation (like 10.0.0.0/8) and extends its prefix
- * to include an additional subnet number. For example, cidrsubnet("10.0.0.0/8", netnum: 2, newbits: 8) returns 10.2.0.0/16;
- * cidrsubnet("2607:f298:6051:516c::/64", netnum: 2, newbits: 8) returns 2607:f298:6051:516c:200::/72.
+ * to include an additional subnet number. For example, cidrsubnet("10.0.0.0/8", netnum: 2, newbits: 8)
+ * returns 10.2.0.0/16; cidrsubnet("2607:f298:6051:516c::/64", netnum: 2, newbits: 8) returns
+ * 2607:f298:6051:516c:200::/72.
  */
 export function cidrsubnetOutput(args: CidrsubnetOutputArgs, opts?: pulumi.InvokeOptions): pulumi.Output<CidrsubnetResult> {
     return pulumi.output(args).apply((a: any) => cidrsubnet(a, opts))

--- a/sdk/python/pulumi_std/cidrsubnet.py
+++ b/sdk/python/pulumi_std/cidrsubnet.py
@@ -44,8 +44,9 @@ def cidrsubnet(input: Optional[str] = None,
                opts: Optional[pulumi.InvokeOptions] = None) -> AwaitableCidrsubnetResult:
     """
     Takes an IP address range in CIDR notation (like 10.0.0.0/8) and extends its prefix
-    to include an additional subnet number. For example, cidrsubnet("10.0.0.0/8", netnum: 2, newbits: 8) returns 10.2.0.0/16;
-    cidrsubnet("2607:f298:6051:516c::/64", netnum: 2, newbits: 8) returns 2607:f298:6051:516c:200::/72.
+    to include an additional subnet number. For example, cidrsubnet("10.0.0.0/8", netnum: 2, newbits: 8)
+    returns 10.2.0.0/16; cidrsubnet("2607:f298:6051:516c::/64", netnum: 2, newbits: 8) returns
+    2607:f298:6051:516c:200::/72.
     """
     __args__ = dict()
     __args__['input'] = input
@@ -65,7 +66,8 @@ def cidrsubnet_output(input: Optional[pulumi.Input[str]] = None,
                       opts: Optional[pulumi.InvokeOptions] = None) -> pulumi.Output[CidrsubnetResult]:
     """
     Takes an IP address range in CIDR notation (like 10.0.0.0/8) and extends its prefix
-    to include an additional subnet number. For example, cidrsubnet("10.0.0.0/8", netnum: 2, newbits: 8) returns 10.2.0.0/16;
-    cidrsubnet("2607:f298:6051:516c::/64", netnum: 2, newbits: 8) returns 2607:f298:6051:516c:200::/72.
+    to include an additional subnet number. For example, cidrsubnet("10.0.0.0/8", netnum: 2, newbits: 8)
+    returns 10.2.0.0/16; cidrsubnet("2607:f298:6051:516c::/64", netnum: 2, newbits: 8) returns
+    2607:f298:6051:516c:200::/72.
     """
     ...

--- a/sdk/python/pulumi_std/cidrsubnet.py
+++ b/sdk/python/pulumi_std/cidrsubnet.py
@@ -44,8 +44,8 @@ def cidrsubnet(input: Optional[str] = None,
                opts: Optional[pulumi.InvokeOptions] = None) -> AwaitableCidrsubnetResult:
     """
     Takes an IP address range in CIDR notation (like 10.0.0.0/8) and extends its prefix
-    to include an additional subnet number. For example, cidrsubnet("10.0.0.0/8", 8, 2) returns 10.2.0.0/16;
-    cidrsubnet("2607:f298:6051:516c::/64", 8, 2) returns 2607:f298:6051:516c:200::/72.
+    to include an additional subnet number. For example, cidrsubnet("10.0.0.0/8", netnum: 2, newbits: 8) returns 10.2.0.0/16;
+    cidrsubnet("2607:f298:6051:516c::/64", netnum: 2, newbits: 8) returns 2607:f298:6051:516c:200::/72.
     """
     __args__ = dict()
     __args__['input'] = input
@@ -65,7 +65,7 @@ def cidrsubnet_output(input: Optional[pulumi.Input[str]] = None,
                       opts: Optional[pulumi.InvokeOptions] = None) -> pulumi.Output[CidrsubnetResult]:
     """
     Takes an IP address range in CIDR notation (like 10.0.0.0/8) and extends its prefix
-    to include an additional subnet number. For example, cidrsubnet("10.0.0.0/8", 8, 2) returns 10.2.0.0/16;
-    cidrsubnet("2607:f298:6051:516c::/64", 8, 2) returns 2607:f298:6051:516c:200::/72.
+    to include an additional subnet number. For example, cidrsubnet("10.0.0.0/8", netnum: 2, newbits: 8) returns 10.2.0.0/16;
+    cidrsubnet("2607:f298:6051:516c::/64", netnum: 2, newbits: 8) returns 2607:f298:6051:516c:200::/72.
     """
     ...

--- a/sdk/schema.json
+++ b/sdk/schema.json
@@ -453,7 +453,7 @@
       }
     },
     "std:index:cidrsubnet": {
-      "description": "Takes an IP address range in CIDR notation (like 10.0.0.0/8) and extends its prefix\nto include an additional subnet number. For example, cidrsubnet(\"10.0.0.0/8\", netnum: 2, newbits: 8) returns 10.2.0.0/16;\ncidrsubnet(\"2607:f298:6051:516c::/64\", netnum: 2, newbits: 8) returns 2607:f298:6051:516c:200::/72.",
+      "description": "Takes an IP address range in CIDR notation (like 10.0.0.0/8) and extends its prefix\nto include an additional subnet number. For example, cidrsubnet(\"10.0.0.0/8\", netnum: 2, newbits: 8)\nreturns 10.2.0.0/16; cidrsubnet(\"2607:f298:6051:516c::/64\", netnum: 2, newbits: 8) returns\n2607:f298:6051:516c:200::/72.",
       "inputs": {
         "properties": {
           "input": {

--- a/sdk/schema.json
+++ b/sdk/schema.json
@@ -453,7 +453,7 @@
       }
     },
     "std:index:cidrsubnet": {
-      "description": "Takes an IP address range in CIDR notation (like 10.0.0.0/8) and extends its prefix\nto include an additional subnet number. For example, cidrsubnet(\"10.0.0.0/8\", 8, 2) returns 10.2.0.0/16;\ncidrsubnet(\"2607:f298:6051:516c::/64\", 8, 2) returns 2607:f298:6051:516c:200::/72.",
+      "description": "Takes an IP address range in CIDR notation (like 10.0.0.0/8) and extends its prefix\nto include an additional subnet number. For example, cidrsubnet(\"10.0.0.0/8\", netnum: 2, newbits: 8) returns 10.2.0.0/16;\ncidrsubnet(\"2607:f298:6051:516c::/64\", netnum: 2, newbits: 8) returns 2607:f298:6051:516c:200::/72.",
       "inputs": {
         "properties": {
           "input": {

--- a/std/cidrsubnet.go
+++ b/std/cidrsubnet.go
@@ -38,8 +38,9 @@ type CidrsubnetResult struct {
 
 func (r *Cidrsubnet) Annotate(a infer.Annotator) {
 	a.Describe(r, `Takes an IP address range in CIDR notation (like 10.0.0.0/8) and extends its prefix
-to include an additional subnet number. For example, cidrsubnet("10.0.0.0/8", netnum: 2, newbits: 8) returns 10.2.0.0/16;
-cidrsubnet("2607:f298:6051:516c::/64", netnum: 2, newbits: 8) returns 2607:f298:6051:516c:200::/72.`)
+to include an additional subnet number. For example, cidrsubnet("10.0.0.0/8", netnum: 2, newbits: 8)
+returns 10.2.0.0/16; cidrsubnet("2607:f298:6051:516c::/64", netnum: 2, newbits: 8) returns
+2607:f298:6051:516c:200::/72.`)
 }
 
 func cidrsubnet(ipaddress string, newbits int, netnum int) (string, error) {

--- a/std/cidrsubnet.go
+++ b/std/cidrsubnet.go
@@ -38,8 +38,8 @@ type CidrsubnetResult struct {
 
 func (r *Cidrsubnet) Annotate(a infer.Annotator) {
 	a.Describe(r, `Takes an IP address range in CIDR notation (like 10.0.0.0/8) and extends its prefix
-to include an additional subnet number. For example, cidrsubnet("10.0.0.0/8", 8, 2) returns 10.2.0.0/16;
-cidrsubnet("2607:f298:6051:516c::/64", 8, 2) returns 2607:f298:6051:516c:200::/72.`)
+to include an additional subnet number. For example, cidrsubnet("10.0.0.0/8", netnum: 2, newbits: 8) returns 10.2.0.0/16;
+cidrsubnet("2607:f298:6051:516c::/64", netnum: 2, newbits: 8) returns 2607:f298:6051:516c:200::/72.`)
 }
 
 func cidrsubnet(ipaddress string, newbits int, netnum int) (string, error) {


### PR DESCRIPTION
The previous comment was not clear on which number is what and actually gives them in a wrong order (at least for Python).

The change adds explicit names to the number parameters.

The actual syntax won't work in any language, but I hope it's intuitive enough so that users can adjust the example to their language manually.

Fix https://github.com/pulumi/pulumi-std/issues/56