### PR TITLE
Updates for GoRelease 2.0

### DIFF
--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -38,7 +38,7 @@ jobs:
     uses: ./.github/workflows/stage-publish.yml
     secrets: inherit
     with:
-      goreleaser-args: -p 10 -f .goreleaser.yml --rm-dist --skip-validate --timeout 60m0s --release-notes=CHANGELOG_PENDING.md
+      goreleaser-args: -p 10 -f .goreleaser.yml --clean --skip=validate --timeout 60m0s --release-notes=CHANGELOG_PENDING.md
       ref: ${{ github.ref }}
   publish_sdk:
     name: Publish SDKs

--- a/.github/workflows/publish-snapshot.yaml
+++ b/.github/workflows/publish-snapshot.yaml
@@ -21,6 +21,6 @@ jobs:
     uses: ./.github/workflows/stage-publish.yml
     secrets: inherit
     with:
-      goreleaser-args: -p 10 -f .goreleaser.prerelease.yml --rm-dist --skip-validate --timeout 60m0s --release-notes=CHANGELOG_PENDING.md
+      goreleaser-args: -p 10 -f .goreleaser.prerelease.yml --clean --skip=validate --timeout 60m0s --release-notes=CHANGELOG_PENDING.md
       ref: ${{ github.ref }}
       use-pulumictl: true

--- a/.github/workflows/stage-publish.yml
+++ b/.github/workflows/stage-publish.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)" >> $GITHUB_ENV
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v6
         with:
           args: ${{ inputs.goreleaser-args }}
           version: latest

--- a/.goreleaser.prerelease.yml
+++ b/.goreleaser.prerelease.yml
@@ -1,7 +1,6 @@
 dist: goreleaser
 project_name: pulumi-std
-changelog:
-  skip: true
+version: 2
 release:
   disable: true
 snapshot:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,6 @@
 dist: goreleaser
 project_name: pulumi-std
+version: 2
 snapshot:
   name_template: "{{ .Version }}-SNAPSHOT"
 checksum:


### PR DESCRIPTION
GoReleaser 2.0 gets installed automatically by the action. Rather than rolling back, fix it forward.

Similar to what we did in https://github.com/pulumi/pulumi-converter-terraform/pull/157