### PR TITLE
Build release binaries with CGO disabled

### DIFF
--- a/.goreleaser.prerelease.yml
+++ b/.goreleaser.prerelease.yml
@@ -13,6 +13,8 @@ archives:
 builds:
   - id: pulumi-resource-std
     binary: pulumi-resource-std
+    env:
+      - CGO_ENABLED=0
     goarch:
       - amd64
       - arm64

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,6 +11,8 @@ archives:
 builds:
   - id: pulumi-resource-std
     binary: pulumi-resource-std
+    env:
+      - CGO_ENABLED=0
     goarch:
       - amd64
       - arm64

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,5 @@
 ### Improvements
 
-- Regenerate SDKs with the latest SDKgen.
-
 ### Bug Fixes
+
+- Build statically linked release binaries with CGO disabled.


### PR DESCRIPTION
For the `v1.7.1` release, the runner used to build the release binaries was switched from macOS to Ubuntu. A side effect of this was that CGO was then enabled by default so the binaries were dynamically linked. This can cause problems when the dynamic dependencies cannot be found (e.g. clib).

This change explicitly disables CGO for static linking (as we do for all our other provider plugin binaries, [for example](https://github.com/pulumi/pulumi-aws/blob/55aac74deef92e1b510badbe864c3c611f8fff19/.goreleaser.yml#L20)).

Fixes #65