### PR TITLE
Regenerate SDKs with the latest SDKgen

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,7 @@
 ### Improvements
 
+- Regenerate SDKs with the latest SDKgen.
+
 ### Bug Fixes
 
 - Build statically linked release binaries with CGO disabled.

--- a/sdk/python/pulumi_std/_utilities.py
+++ b/sdk/python/pulumi_std/_utilities.py
@@ -100,10 +100,6 @@ def _get_semver_version():
 _version = _get_semver_version()
 _version_str = str(_version)
 
-
-def get_version():
-    return _version_str
-
 def get_resource_opts_defaults() -> pulumi.ResourceOptions:
     return pulumi.ResourceOptions(
         version=get_version(),
@@ -324,3 +320,6 @@ def deprecated(message: str) -> typing.Callable[[C], C]:
 
 def get_plugin_download_url():
 	return None
+
+def get_version():
+     return _version_str

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -36,7 +36,7 @@ setup(name='pulumi_std',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi',
+          'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)


### PR DESCRIPTION
There have been some minor adjustments to Python's generated provider SDK in `pulumi` `v3.122.0`. Regenerate so we don't get `git` worktree dirty errors during release.