### PR TITLE
Use latest patch version of go in CI

### DIFF
--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -50,9 +50,10 @@ jobs:
       - name: Unshallow clone for tags
         run: git fetch --prune --unshallow --tags
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.goversion }}
+          check-latest: true
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.5.0
         with:
@@ -139,9 +140,10 @@ jobs:
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
-        go-version: ${{ env.GOVERSION }}
+        go-version: "1.21.x"
+        check-latest: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:

--- a/.github/workflows/stage-publish.yml
+++ b/.github/workflows/stage-publish.yml
@@ -31,9 +31,10 @@ jobs:
       - name: Unshallow clone for tags
         run: git fetch --prune --unshallow --tags || true
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: 1.21.x
+          check-latest: true
       - name: Install pulumictl
         if: ${{ inputs.use-pulumictl }}
         uses: jaxxstorm/action-install-gh-release@v1.12.0

--- a/.github/workflows/stage-test.yml
+++ b/.github/workflows/stage-test.yml
@@ -22,14 +22,13 @@ jobs:
         with:
           ref: ${{ inputs.commit-ref }}
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
-          stable: ${{ matrix.go-stable }}
+          check-latest: true
       - name: Test
         run: make test
     strategy:
       fail-fast: false
       matrix:
         go-version: [1.21.x]
-        go-stable: [true]

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,7 +1,6 @@
 ### Improvements
 
-- Regenerate SDKs with the latest SDKgen.
+- Use latest patch version of go in CI.
 
 ### Bug Fixes
 
-- Build statically linked release binaries with CGO disabled.


### PR DESCRIPTION
Similar to https://github.com/pulumi/pulumi/pull/16609

We pass a version like `1.21.x` for go, which results in the setup-go action using a cached version, even if there is a more recent release available. Set `check-latest: true` to ensure we're always using the latest release, picking up any security fixes.

Unblocks https://github.com/pulumi/pulumi-std/issues/69