### PR TITLE
Implement `compact` to more closely match Terraform

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,6 +1,7 @@
 ### Improvements
 
 - Use latest patch version of go in CI.
+- Handle `null` values in `compact`.
 
 ### Bug Fixes
 

--- a/sdk/dotnet/Compact.cs
+++ b/sdk/dotnet/Compact.cs
@@ -12,19 +12,19 @@ namespace Pulumi.Std
     public static class Compact
     {
         /// <summary>
-        /// Removes empty string elements from a list.
+        /// Removes empty and nil string elements from a list.
         /// </summary>
         public static Task<CompactResult> InvokeAsync(CompactArgs args, InvokeOptions? options = null)
             => global::Pulumi.Deployment.Instance.InvokeAsync<CompactResult>("std:index:compact", args ?? new CompactArgs(), options.WithDefaults());
 
         /// <summary>
-        /// Removes empty string elements from a list.
+        /// Removes empty and nil string elements from a list.
         /// </summary>
         public static Output<CompactResult> Invoke(CompactInvokeArgs args, InvokeOptions? options = null)
             => global::Pulumi.Deployment.Instance.Invoke<CompactResult>("std:index:compact", args ?? new CompactInvokeArgs(), options.WithDefaults());
 
         /// <summary>
-        /// Removes empty string elements from a list.
+        /// Removes empty and nil string elements from a list.
         /// </summary>
         public static Output<CompactResult> Invoke(CompactInvokeArgs args, InvokeOutputOptions options)
             => global::Pulumi.Deployment.Instance.Invoke<CompactResult>("std:index:compact", args ?? new CompactInvokeArgs(), options.WithDefaults());
@@ -34,10 +34,10 @@ namespace Pulumi.Std
     public sealed class CompactArgs : global::Pulumi.InvokeArgs
     {
         [Input("input", required: true)]
-        private List<string>? _input;
-        public List<string> Input
+        private List<object>? _input;
+        public List<object> Input
         {
-            get => _input ?? (_input = new List<string>());
+            get => _input ?? (_input = new List<object>());
             set => _input = value;
         }
 
@@ -50,10 +50,10 @@ namespace Pulumi.Std
     public sealed class CompactInvokeArgs : global::Pulumi.InvokeArgs
     {
         [Input("input", required: true)]
-        private InputList<string>? _input;
-        public InputList<string> Input
+        private InputList<object>? _input;
+        public InputList<object> Input
         {
-            get => _input ?? (_input = new InputList<string>());
+            get => _input ?? (_input = new InputList<object>());
             set => _input = value;
         }
 

--- a/sdk/go/std/compact.go
+++ b/sdk/go/std/compact.go
@@ -11,7 +11,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
-// Removes empty string elements from a list.
+// Removes empty and nil string elements from a list.
 func Compact(ctx *pulumi.Context, args *CompactArgs, opts ...pulumi.InvokeOption) (*CompactResult, error) {
 	opts = internal.PkgInvokeDefaultOpts(opts)
 	var rv CompactResult
@@ -23,7 +23,7 @@ func Compact(ctx *pulumi.Context, args *CompactArgs, opts ...pulumi.InvokeOption
 }
 
 type CompactArgs struct {
-	Input []string `pulumi:"input"`
+	Input []interface{} `pulumi:"input"`
 }
 
 type CompactResult struct {
@@ -40,7 +40,7 @@ func CompactOutput(ctx *pulumi.Context, args CompactOutputArgs, opts ...pulumi.I
 }
 
 type CompactOutputArgs struct {
-	Input pulumi.StringArrayInput `pulumi:"input"`
+	Input pulumi.ArrayInput `pulumi:"input"`
 }
 
 func (CompactOutputArgs) ElementType() reflect.Type {

--- a/sdk/nodejs/compact.ts
+++ b/sdk/nodejs/compact.ts
@@ -5,7 +5,7 @@ import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "./utilities";
 
 /**
- * Removes empty string elements from a list.
+ * Removes empty and nil string elements from a list.
  */
 export function compact(args: CompactArgs, opts?: pulumi.InvokeOptions): Promise<CompactResult> {
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
@@ -15,14 +15,14 @@ export function compact(args: CompactArgs, opts?: pulumi.InvokeOptions): Promise
 }
 
 export interface CompactArgs {
-    input: string[];
+    input: any[];
 }
 
 export interface CompactResult {
     readonly result: string[];
 }
 /**
- * Removes empty string elements from a list.
+ * Removes empty and nil string elements from a list.
  */
 export function compactOutput(args: CompactOutputArgs, opts?: pulumi.InvokeOutputOptions): pulumi.Output<CompactResult> {
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
@@ -32,5 +32,5 @@ export function compactOutput(args: CompactOutputArgs, opts?: pulumi.InvokeOutpu
 }
 
 export interface CompactOutputArgs {
-    input: pulumi.Input<pulumi.Input<string>[]>;
+    input: pulumi.Input<any[]>;
 }

--- a/sdk/python/pulumi_std/compact.py
+++ b/sdk/python/pulumi_std/compact.py
@@ -43,10 +43,10 @@ class AwaitableCompactResult(CompactResult):
             result=self.result)
 
 
-def compact(input: Optional[Sequence[str]] = None,
+def compact(input: Optional[Sequence[Any]] = None,
             opts: Optional[pulumi.InvokeOptions] = None) -> AwaitableCompactResult:
     """
-    Removes empty string elements from a list.
+    Removes empty and nil string elements from a list.
     """
     __args__ = dict()
     __args__['input'] = input
@@ -55,10 +55,10 @@ def compact(input: Optional[Sequence[str]] = None,
 
     return AwaitableCompactResult(
         result=pulumi.get(__ret__, 'result'))
-def compact_output(input: Optional[pulumi.Input[Sequence[str]]] = None,
+def compact_output(input: Optional[pulumi.Input[Sequence[Any]]] = None,
                    opts: Optional[Union[pulumi.InvokeOptions, pulumi.InvokeOutputOptions]] = None) -> pulumi.Output[CompactResult]:
     """
-    Removes empty string elements from a list.
+    Removes empty and nil string elements from a list.
     """
     __args__ = dict()
     __args__['input'] = input

--- a/sdk/schema.json
+++ b/sdk/schema.json
@@ -543,13 +543,13 @@
       }
     },
     "std:index:compact": {
-      "description": "Removes empty string elements from a list.",
+      "description": "Removes empty and nil string elements from a list.",
       "inputs": {
         "properties": {
           "input": {
             "type": "array",
             "items": {
-              "type": "string"
+              "$ref": "pulumi.json#/Any"
             }
           }
         },

--- a/tests/Pulumi.yaml
+++ b/tests/Pulumi.yaml
@@ -22,7 +22,7 @@ variables:
   base64decode:
     fn::std:base64decode:
       input: QUJDREU=
-  basename: 
+  basename:
     fn::std:basename:
       input: path/to/pulumi
   base64gzip:
@@ -73,7 +73,16 @@ variables:
       input: [[], [1]]
   compact:
     fn::std:compact:
-      input: ["", "one", ""]
+      input: ["", "one", "", null]
+  compactMixed:
+    fn::std:compact:
+      input: ["", "one", "", null, "two"]
+  compactMixedEmpty:
+    fn::std:compact:
+      input: ["", "", null]
+  compactNullsEmpty:
+    fn::std:compact:
+      input: [null, null]
   concat:
     fn::std:concat:
       input: [[1,2], [3,4], [5]]
@@ -172,7 +181,7 @@ variables:
   jsondecode:
     fn::std:jsondecode:
       input: '{"str": "hello", "num":6.13,"strs":["a","b"], "bool": true}'
-  keys: 
+  keys:
     fn::std:keys:
       input:
         hello: world
@@ -258,7 +267,7 @@ variables:
       length: 5
   transpose:
     fn::std:transpose:
-      input: 
+      input:
         a: ["1", "2"]
         b: ["2", "3"]
   title:
@@ -293,7 +302,7 @@ variables:
   tonumberStr:
     fn::std:tonumber:
       input: "10"
-  tostringStr: 
+  tostringStr:
     fn::std:tostring:
       input: "hello world"
   tostringInt:
@@ -361,6 +370,9 @@ outputs:
   coalesce: ${coalesce.result}
   coalescelist: ${coalescelist.result}
   compact: ${compact.result}
+  compactMixed: ${compactMixed.result}
+  compactMixedEmpty: ${compactMixedEmpty.result}
+  compactNullsEmpty: ${compactNullsEmpty.result}
   concat: ${concat.result}
   containsWithIntegers: ${containsWithIntegers.result}
   containsWithStrings: ${containsWithStrings.result}

--- a/tests/main.go
+++ b/tests/main.go
@@ -1,4 +1,4 @@
-// Copyright 2022, Pulumi Corporation.
+// Copyright 2022-2025, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -113,6 +113,9 @@ func expectedOutputs() map[string]interface{} {
 		"coalesce":                   "hello",
 		"coalescelist":               []interface{}{1},
 		"compact":                    []string{"one"},
+		"compactMixed":               []string{"one", "two"},
+		"compactMixedEmpty":          []string{},
+		"compactNullsEmpty":          []string{},
 		"concat":                     []int{1, 2, 3, 4, 5},
 		"containsWithIntegers":       true,
 		"containsWithStrings":        true,


### PR DESCRIPTION
`compact` now accepts any object, to permit `null`s. These are removed as part of its implementation, so it still returns a list of strings.

Part of https://github.com/pulumi/pulumi/issues/18406