### PR TITLE
Add a `CODEOWNERS` file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @pulumi/platform


### PR DESCRIPTION
This change adds `.github/CODEOWNERS`, so that GitHub will automatically request reviews from `@pulumi/platform` for PRs raised in this repository.