### PR TITLE
Bulk out tests for `distinct`

### DIFF
--- a/tests/Pulumi.yaml
+++ b/tests/Pulumi.yaml
@@ -149,6 +149,9 @@ variables:
   dirname:
     fn::std:dirname:
       input: /path/to/directory/file.txt
+  distinctWithBooleans:
+    fn::std:distinct:
+      input: [true, false, true, true, false, true, false]
   distinctWithIntegers:
     fn::std:distinct:
       input: [1,2,2,3,3,4,5]
@@ -496,7 +499,9 @@ outputs:
   csvdecode: ${csvdecode.result}
   shouldNotContain: ${shouldNotContain.result}
   dirname: ${dirname.result}
+  distinctWithBooleans: ${distinctWithBooleans.result}
   distinctWithIntegers: ${distinctWithIntegers.result}
+  distinctWithStrings: ${distinctWithStrings.result}
   element: ${element.result}
   elementOverflow: ${elementOverflow.result}
   elementNegativeIndex: ${elementNegativeIndex.result}

--- a/tests/main.go
+++ b/tests/main.go
@@ -138,6 +138,7 @@ func expectedOutputs() map[string]interface{} {
 		"csvdecode":                      []map[string]string{{"a": "1", "b": "2", "c": "3"}, {"a": "4", "b": "5", "c": "6"}},
 		"shouldNotContain":               false,
 		"dirname":                        "/path/to/directory",
+		"distinctWithBooleans":           []bool{true, false},
 		"distinctWithIntegers":           []int{1, 2, 3, 4, 5},
 		"distinctWithStrings":            []string{"one", "two", "three"},
 		"element":                        20,


### PR DESCRIPTION
We want to start using `distinct` in `pulumi convert`. The current implementation is likely not perfect for all cases (e.g. objects), but it should suffice for primitive types, which hopefully will substantially increase the completeness of `pulumi convert`. This commit just adds a test case for booleans, and exposes the existing one for strings that was not actually being run.

Part of pulumi/pulumi#18517