### PR TITLE
Ensure that all expected outputs appear

### DIFF
--- a/sdk/dotnet/Cidrsubnets.cs
+++ b/sdk/dotnet/Cidrsubnets.cs
@@ -12,25 +12,19 @@ namespace Pulumi.Std
     public static class Cidrsubnets
     {
         /// <summary>
-        /// Takes an IP address prefix in CIDR notation (like 10.0.0.0/8) and creates a series of 
-        /// consecutive IP address ranges within that CIDR prefix. See https://opentofu.org/docs/language/functions/cidrsubnets/ 
-        /// for additional information
+        /// Takes an IP address prefix in CIDR notation (like 10.0.0.0/8) and creates a series of consecutive IP address ranges within that CIDR prefix. See https://opentofu.org/docs/language/functions/cidrsubnets/ for additional information
         /// </summary>
         public static Task<CidrsubnetsResult> InvokeAsync(CidrsubnetsArgs args, InvokeOptions? options = null)
             => global::Pulumi.Deployment.Instance.InvokeAsync<CidrsubnetsResult>("std:index:cidrsubnets", args ?? new CidrsubnetsArgs(), options.WithDefaults());
 
         /// <summary>
-        /// Takes an IP address prefix in CIDR notation (like 10.0.0.0/8) and creates a series of 
-        /// consecutive IP address ranges within that CIDR prefix. See https://opentofu.org/docs/language/functions/cidrsubnets/ 
-        /// for additional information
+        /// Takes an IP address prefix in CIDR notation (like 10.0.0.0/8) and creates a series of consecutive IP address ranges within that CIDR prefix. See https://opentofu.org/docs/language/functions/cidrsubnets/ for additional information
         /// </summary>
         public static Output<CidrsubnetsResult> Invoke(CidrsubnetsInvokeArgs args, InvokeOptions? options = null)
             => global::Pulumi.Deployment.Instance.Invoke<CidrsubnetsResult>("std:index:cidrsubnets", args ?? new CidrsubnetsInvokeArgs(), options.WithDefaults());
 
         /// <summary>
-        /// Takes an IP address prefix in CIDR notation (like 10.0.0.0/8) and creates a series of 
-        /// consecutive IP address ranges within that CIDR prefix. See https://opentofu.org/docs/language/functions/cidrsubnets/ 
-        /// for additional information
+        /// Takes an IP address prefix in CIDR notation (like 10.0.0.0/8) and creates a series of consecutive IP address ranges within that CIDR prefix. See https://opentofu.org/docs/language/functions/cidrsubnets/ for additional information
         /// </summary>
         public static Output<CidrsubnetsResult> Invoke(CidrsubnetsInvokeArgs args, InvokeOutputOptions options)
             => global::Pulumi.Deployment.Instance.Invoke<CidrsubnetsResult>("std:index:cidrsubnets", args ?? new CidrsubnetsInvokeArgs(), options.WithDefaults());

--- a/sdk/go/std/cidrsubnets.go
+++ b/sdk/go/std/cidrsubnets.go
@@ -11,9 +11,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
-// Takes an IP address prefix in CIDR notation (like 10.0.0.0/8) and creates a series of
-// consecutive IP address ranges within that CIDR prefix. See https://opentofu.org/docs/language/functions/cidrsubnets/
-// for additional information
+// Takes an IP address prefix in CIDR notation (like 10.0.0.0/8) and creates a series of consecutive IP address ranges within that CIDR prefix. See https://opentofu.org/docs/language/functions/cidrsubnets/ for additional information
 func Cidrsubnets(ctx *pulumi.Context, args *CidrsubnetsArgs, opts ...pulumi.InvokeOption) (*CidrsubnetsResult, error) {
 	opts = internal.PkgInvokeDefaultOpts(opts)
 	var rv CidrsubnetsResult

--- a/sdk/java/src/main/java/com/pulumi/std/StdFunctions.java
+++ b/sdk/java/src/main/java/com/pulumi/std/StdFunctions.java
@@ -979,45 +979,35 @@ public final class StdFunctions {
         return Deployment.getInstance().invokeAsync("std:index:cidrsubnet", TypeShape.of(CidrsubnetResult.class), args, Utilities.withVersion(options));
     }
     /**
-     * Takes an IP address prefix in CIDR notation (like 10.0.0.0/8) and creates a series of
-     * consecutive IP address ranges within that CIDR prefix. See https://opentofu.org/docs/language/functions/cidrsubnets/
-     * for additional information
+     * Takes an IP address prefix in CIDR notation (like 10.0.0.0/8) and creates a series of consecutive IP address ranges within that CIDR prefix. See https://opentofu.org/docs/language/functions/cidrsubnets/ for additional information
      * 
      */
     public static Output<CidrsubnetsResult> cidrsubnets(CidrsubnetsArgs args) {
         return cidrsubnets(args, InvokeOptions.Empty);
     }
     /**
-     * Takes an IP address prefix in CIDR notation (like 10.0.0.0/8) and creates a series of
-     * consecutive IP address ranges within that CIDR prefix. See https://opentofu.org/docs/language/functions/cidrsubnets/
-     * for additional information
+     * Takes an IP address prefix in CIDR notation (like 10.0.0.0/8) and creates a series of consecutive IP address ranges within that CIDR prefix. See https://opentofu.org/docs/language/functions/cidrsubnets/ for additional information
      * 
      */
     public static CompletableFuture<CidrsubnetsResult> cidrsubnetsPlain(CidrsubnetsPlainArgs args) {
         return cidrsubnetsPlain(args, InvokeOptions.Empty);
     }
     /**
-     * Takes an IP address prefix in CIDR notation (like 10.0.0.0/8) and creates a series of
-     * consecutive IP address ranges within that CIDR prefix. See https://opentofu.org/docs/language/functions/cidrsubnets/
-     * for additional information
+     * Takes an IP address prefix in CIDR notation (like 10.0.0.0/8) and creates a series of consecutive IP address ranges within that CIDR prefix. See https://opentofu.org/docs/language/functions/cidrsubnets/ for additional information
      * 
      */
     public static Output<CidrsubnetsResult> cidrsubnets(CidrsubnetsArgs args, InvokeOptions options) {
         return Deployment.getInstance().invoke("std:index:cidrsubnets", TypeShape.of(CidrsubnetsResult.class), args, Utilities.withVersion(options));
     }
     /**
-     * Takes an IP address prefix in CIDR notation (like 10.0.0.0/8) and creates a series of
-     * consecutive IP address ranges within that CIDR prefix. See https://opentofu.org/docs/language/functions/cidrsubnets/
-     * for additional information
+     * Takes an IP address prefix in CIDR notation (like 10.0.0.0/8) and creates a series of consecutive IP address ranges within that CIDR prefix. See https://opentofu.org/docs/language/functions/cidrsubnets/ for additional information
      * 
      */
     public static Output<CidrsubnetsResult> cidrsubnets(CidrsubnetsArgs args, InvokeOutputOptions options) {
         return Deployment.getInstance().invoke("std:index:cidrsubnets", TypeShape.of(CidrsubnetsResult.class), args, Utilities.withVersion(options));
     }
     /**
-     * Takes an IP address prefix in CIDR notation (like 10.0.0.0/8) and creates a series of
-     * consecutive IP address ranges within that CIDR prefix. See https://opentofu.org/docs/language/functions/cidrsubnets/
-     * for additional information
+     * Takes an IP address prefix in CIDR notation (like 10.0.0.0/8) and creates a series of consecutive IP address ranges within that CIDR prefix. See https://opentofu.org/docs/language/functions/cidrsubnets/ for additional information
      * 
      */
     public static CompletableFuture<CidrsubnetsResult> cidrsubnetsPlain(CidrsubnetsPlainArgs args, InvokeOptions options) {

--- a/sdk/nodejs/cidrsubnets.ts
+++ b/sdk/nodejs/cidrsubnets.ts
@@ -5,9 +5,7 @@ import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "./utilities";
 
 /**
- * Takes an IP address prefix in CIDR notation (like 10.0.0.0/8) and creates a series of
- * consecutive IP address ranges within that CIDR prefix. See https://opentofu.org/docs/language/functions/cidrsubnets/
- * for additional information
+ * Takes an IP address prefix in CIDR notation (like 10.0.0.0/8) and creates a series of consecutive IP address ranges within that CIDR prefix. See https://opentofu.org/docs/language/functions/cidrsubnets/ for additional information
  */
 export function cidrsubnets(args: CidrsubnetsArgs, opts?: pulumi.InvokeOptions): Promise<CidrsubnetsResult> {
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
@@ -26,9 +24,7 @@ export interface CidrsubnetsResult {
     readonly result: string[];
 }
 /**
- * Takes an IP address prefix in CIDR notation (like 10.0.0.0/8) and creates a series of
- * consecutive IP address ranges within that CIDR prefix. See https://opentofu.org/docs/language/functions/cidrsubnets/
- * for additional information
+ * Takes an IP address prefix in CIDR notation (like 10.0.0.0/8) and creates a series of consecutive IP address ranges within that CIDR prefix. See https://opentofu.org/docs/language/functions/cidrsubnets/ for additional information
  */
 export function cidrsubnetsOutput(args: CidrsubnetsOutputArgs, opts?: pulumi.InvokeOutputOptions): pulumi.Output<CidrsubnetsResult> {
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});

--- a/sdk/python/pulumi_std/cidrsubnets.py
+++ b/sdk/python/pulumi_std/cidrsubnets.py
@@ -47,9 +47,7 @@ def cidrsubnets(input: Optional[str] = None,
                 newbits: Optional[Sequence[int]] = None,
                 opts: Optional[pulumi.InvokeOptions] = None) -> AwaitableCidrsubnetsResult:
     """
-    Takes an IP address prefix in CIDR notation (like 10.0.0.0/8) and creates a series of
-    consecutive IP address ranges within that CIDR prefix. See https://opentofu.org/docs/language/functions/cidrsubnets/
-    for additional information
+    Takes an IP address prefix in CIDR notation (like 10.0.0.0/8) and creates a series of consecutive IP address ranges within that CIDR prefix. See https://opentofu.org/docs/language/functions/cidrsubnets/ for additional information
     """
     __args__ = dict()
     __args__['input'] = input
@@ -63,9 +61,7 @@ def cidrsubnets_output(input: Optional[pulumi.Input[str]] = None,
                        newbits: Optional[pulumi.Input[Sequence[int]]] = None,
                        opts: Optional[Union[pulumi.InvokeOptions, pulumi.InvokeOutputOptions]] = None) -> pulumi.Output[CidrsubnetsResult]:
     """
-    Takes an IP address prefix in CIDR notation (like 10.0.0.0/8) and creates a series of
-    consecutive IP address ranges within that CIDR prefix. See https://opentofu.org/docs/language/functions/cidrsubnets/
-    for additional information
+    Takes an IP address prefix in CIDR notation (like 10.0.0.0/8) and creates a series of consecutive IP address ranges within that CIDR prefix. See https://opentofu.org/docs/language/functions/cidrsubnets/ for additional information
     """
     __args__ = dict()
     __args__['input'] = input

--- a/sdk/schema.json
+++ b/sdk/schema.json
@@ -485,7 +485,7 @@
       }
     },
     "std:index:cidrsubnets": {
-      "description": "Takes an IP address prefix in CIDR notation (like 10.0.0.0/8) and creates a series of \nconsecutive IP address ranges within that CIDR prefix. See https://opentofu.org/docs/language/functions/cidrsubnets/ \nfor additional information",
+      "description": "Takes an IP address prefix in CIDR notation (like 10.0.0.0/8) and creates a series of consecutive IP address ranges within that CIDR prefix. See https://opentofu.org/docs/language/functions/cidrsubnets/ for additional information",
       "inputs": {
         "properties": {
           "input": {

--- a/tests/Pulumi.yaml
+++ b/tests/Pulumi.yaml
@@ -570,6 +570,10 @@ outputs:
   cidrhostV2: ${cidrhostV2.result}
   cidrnetmask: ${cidrnetmask.result}
   cidrsubnet: ${cidrsubnet.result}
+  cidrsubnetsEmpty: ${cidrsubnetsEmpty.result}
+  cidrsubnetsSingle: ${cidrsubnetsSingle.result}
+  cidrsubnetsBasic: ${cidrsubnetsBasic.result}
+  cidrsubnetsIpv6: ${cidrsubnetsIpv6.result}
   coalesce: ${coalesce.result}
   coalesceWithNil: ${coalesceWithNil.result}
   coalesceWithInts: ${coalesceWithInts.result}
@@ -612,6 +616,7 @@ outputs:
   filebase64sha512: ${filebase64sha512.result}
   flatten: ${flatten.result}
   flattenWithStrings: ${flattenWithStrings.result}
+  floor: ${floor.result}
   formatPercent: ${formatPercent.result}
   formatValues: ${formatValues.result}
   formatJSONs: ${formatJSONs.result}

--- a/tests/main.go
+++ b/tests/main.go
@@ -282,12 +282,15 @@ func main() {
 	expected := expectedOutputs()
 	outputs := outputs()
 
+	seen := make(map[string]bool)
 	for key, value := range outputs {
+		seen[key] = true
+
 		if key == "pathexpand" {
 			// pathexpand is a special case, because it returns a different value on each machine
 			if strings.Contains(value.(string), "~") {
 				fmt.Printf("❌ Output '%s' => '%s' did not expand the home directory", key, value)
-				exitCode++
+				exitCode = 1
 			}
 		}
 
@@ -314,7 +317,14 @@ func main() {
 			fmt.Printf("✅ Output '%s' has value '%v' as expected\n", key, originalValue)
 		} else {
 			fmt.Printf("❌ Output '%s' was '%v' but should be '%v'\n", key, originalValue, originalExpectedValue)
-			exitCode++
+			exitCode = 1
+		}
+	}
+
+	for key := range expected {
+		if !seen[key] {
+			fmt.Printf("❌ Expected output '%s' was not present\n", key)
+			exitCode = 1
 		}
 	}
 }


### PR DESCRIPTION
Currently, the test suite for this provider walks the list of actual outputs and asserts that the values encountered match the declared expected values. It does not however ensure that every expected value has a corresponding actual output. As a result it's possible to add an expectation that is not being tested, giving false confidence that coverage is being added. This change fixes this by walking the list of expected outputs after the fact and asserting that we saw each one of them.